### PR TITLE
add Windows 11 compatibility with powershell script and other mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It then adds a link into your org file and turns ON `display-inline-images` show
 
 - Linux: scrot (for taking screenshots);
 - MacOS: screencapture (built-in for Mojave, Catalina, Big Sur, Monterey...)
+- Powershell: Powershell executable is found as `powershell.exe` within wsl2 installations
 - Emacs: 24.1
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It then adds a link into your org file and turns ON `display-inline-images` show
 
 - Linux: scrot (for taking screenshots);
 - MacOS: screencapture (built-in for Mojave, Catalina, Big Sur, Monterey...)
-- WSL2: powershell.exe (found within the wsl2 installation)
+- Windows: powershell.exe (compatible with native Windows and WSL installations)
 - Emacs: 24.1
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It then adds a link into your org file and turns ON `display-inline-images` show
 
 - Linux: scrot (for taking screenshots);
 - MacOS: screencapture (built-in for Mojave, Catalina, Big Sur, Monterey...)
-- Powershell: Powershell executable is found as `powershell.exe` within wsl2 installations
+- WSL2: powershell.exe (found within the wsl2 installation)
 - Emacs: 24.1
 
 ## Install

--- a/org-ros.el
+++ b/org-ros.el
@@ -44,7 +44,7 @@
   "Secondary screencapture software selection switch."
   :type 'string)
 
-(defcustom org-ros-powershell-screencapture "powershell.exe"
+(defcustom org-ros-windows-screencapture "powershell.exe"
   "Powershell screencapture software (for people using wsl2)."
   :type 'string)
 
@@ -80,7 +80,7 @@
                  (call-process org-ros-primary-screencapture nil nil nil org-ros-primary-screencapture-switch filepath))
                 ((executable-find org-ros-secondary-screencapture)
                  (call-process org-ros-secondary-screencapture nil nil nil org-ros-secondary-screencapture-switch filepath))
-                ((executable-find org-ros-powershell-screencapture)
+                ((executable-find org-ros-windows-screencapture)
                  (start-process "powershell" "*PowerShell*" "powershell.exe" "-File" (expand-file-name "./printsc.ps1" org-ros-dir) filepath)))
 
           (insert "[[" filepath "]" "[" display-name "]]")

--- a/org-ros.el
+++ b/org-ros.el
@@ -45,7 +45,7 @@
   :type 'string)
 
 (defcustom org-ros-windows-screencapture "powershell.exe"
-  "Powershell screencapture software (for people using wsl2)."
+  "Windows screencapture software."
   :type 'string)
 
 (defcustom org-ros-subdirectory ""

--- a/printsc.ps1
+++ b/printsc.ps1
@@ -1,0 +1,14 @@
+Add-Type -AssemblyName System.Windows.Forms
+[Windows.Forms.Sendkeys]::SendWait('{Prtsc}')
+$file = $args[0]
+[Windows.Forms.Clipboard]::Clear()
+while ($true) {
+    $img = [Windows.Forms.Clipboard]::GetImage()
+    if (-not [System.Object]::ReferenceEquals($img, $null)) {
+        Write-Output "Clipboard image retrieved successfully."
+        $img.Save($file, [Drawing.Imaging.ImageFormat]::Png)
+        Write-Output "Image saved to $file"
+        break
+    }
+    Start-Sleep -Milliseconds 100
+}


### PR DESCRIPTION
# Why

Currently there's no good way of getting screenshots when using wsl and emacs. 

# How

This PR would provide a workaround where emacs calls a powershell script that sends a `PrtSc` event and allows the user to select the region to screenshot. 

## Details 

Create conditional logic that includes powershell in screenshot software options.

Powershell script uses powershell.exe to call PrnSc button and waits for image to load to clipboard after selection

(which is the reason why `start-process` was used instead of
    `call-process`)

## UI/UX extras
Added functionality to create a subdirectory when saving screenshots. Also allow for users to name the link saved for readability