### PR TITLE
Change secondary screencapture switch to '-i'

### DIFF
--- a/org-ros.el
+++ b/org-ros.el
@@ -40,7 +40,7 @@
   "Secondary screencapture software, if first fails to load (usually set to MacOS systems)."
   :type 'string)
 
-(defcustom org-ros-secondary-screencapture-switch "-s"
+(defcustom org-ros-secondary-screencapture-switch "-i"
   "Secondary screencapture software selection switch."
   :type 'string)
 


### PR DESCRIPTION
with interactive mode, the default action is same as "-s" , while you can switch to "window" capture mode by press "space ".  kind of convenient.